### PR TITLE
Potential fix for code scanning alert no. 38: Android WebView settings allows access to content links

### DIFF
--- a/feature/import/src/main/java/com/dawncourse/feature/import_module/ImportScreen.kt
+++ b/feature/import/src/main/java/com/dawncourse/feature/import_module/ImportScreen.kt
@@ -83,6 +83,12 @@ import java.time.ZoneId
 import java.time.LocalDate
 import kotlin.coroutines.resume
 
+private fun configureImportWebViewSecurity(webView: WebView) {
+    val settings = webView.settings
+    // Disable access to content:// URLs to avoid exposing protected content
+    settings.allowContentAccess = false
+}
+
 /**
  * 导入功能主屏幕
  *


### PR DESCRIPTION
Potential fix for [https://github.com/HF-CYGG/Dawn-Course/security/code-scanning/38](https://github.com/HF-CYGG/Dawn-Course/security/code-scanning/38)

In general, to fix this issue you should obtain the `WebSettings` instance from the `WebView` and explicitly disable content URL access by calling `settings.allowContentAccess = false` (or `settings.setAllowContentAccess(false)` in Java). This ensures JavaScript running within the WebView cannot access `content://` URIs, reducing the risk of exposing protected content through a malicious or compromised page.

In this file, the only relevant piece of information is the use of a `webView` instance around line 744, which implies there is code (not shown) that creates/configures this WebView, likely via `AndroidView` earlier in `ImportScreen.kt`. The best, least invasive fix is to add a `WebViewClient` / configuration block at the point where the `WebView` is created and set `webView.settings.allowContentAccess = false` there. Since we cannot see that block, but we can edit anywhere in this file, we should add a small helper function that hardens a `WebView` and then call it immediately after the `WebView` is created (in the existing AndroidView factory). That way, existing functionality is preserved and only security-related defaults are tightened.

Concretely:
- Add a private helper such as `private fun configureImportWebViewSecurity(webView: WebView)` near the top or bottom of the file.
- In that function, call `val settings = webView.settings` and then `settings.allowContentAccess = false`.
- Update the AndroidView factory (the code where `webView` is instantiated and assigned to the `webView` variable used at line 744) to call `configureImportWebViewSecurity(webView)` right after creating the `WebView`. This does not change navigation or JavaScript behavior beyond disabling access to `content://` links.
- No new imports are required, since `WebView` is already imported and `WebSettings` is part of the Android SDK.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
